### PR TITLE
Fix Incorrect Cursors Data on DM Messages GET API

### DIFF
--- a/backend/__tests__/controllers/message.test.ts
+++ b/backend/__tests__/controllers/message.test.ts
@@ -952,7 +952,6 @@ describe("Test DM messages get controller", () => {
   });
 
   test("Return correct cursor when the direction query is backward", done => {
-    const lastIndex: number = DMMessages.length - 1;
     const limit: number = 2;
     agent
       .get(
@@ -963,18 +962,17 @@ describe("Test DM messages get controller", () => {
       .expect((res: Response) => {
         const prevCursor: string = res.body.prevCursor;
         const nextCursor: string = res.body.nextCursor;
-        console.log({ lastMessage: DMMessages[lastIndex] });
         expect(prevCursor).toBe(
           constructMessageCursor({
-            id: DMMessages[limit - 1].id,
-            createdAt: DMMessages[limit - 1].createdAt,
+            id: DMMessages[0].id,
+            createdAt: DMMessages[0].createdAt,
           }),
         );
 
         expect(nextCursor).toBe(
           constructMessageCursor({
-            id: DMMessages[0].id,
-            createdAt: DMMessages[0].createdAt,
+            id: DMMessages[limit - 1].id,
+            createdAt: DMMessages[limit - 1].createdAt,
           }),
         );
       })

--- a/backend/controllers/message.ts
+++ b/backend/controllers/message.ts
@@ -557,7 +557,7 @@ const dm_messages_get = [
       direction,
     });
 
-    const { prevCursor, nextCursor } = getMsgCursors(messages, direction);
+    const { prevCursor, nextCursor } = getMsgCursors(messages);
 
     res.json({
       message: `Successfully fetched messages`,

--- a/backend/utils/cursor.ts
+++ b/backend/utils/cursor.ts
@@ -74,7 +74,6 @@ const constructMessageCursor = ({
 
 const getMsgCursors = (
   messages: Message[],
-  direction: "backward" | "forward",
 ): {
   prevCursor: string | null;
   nextCursor: string | null;
@@ -89,12 +88,10 @@ const getMsgCursors = (
       : null;
 
   // Get the oldest message as the previous cursor
-  const prevCursor: string | null =
-    direction === "backward" ? lastMsgCursor : firstMsgCursor;
+  const prevCursor: string | null = firstMsgCursor;
 
   // Get the latest message as the next cursor
-  const nextCursor: string | null =
-    direction === "backward" ? firstMsgCursor : lastMsgCursor;
+  const nextCursor: string | null = lastMsgCursor;
 
   return {
     prevCursor,


### PR DESCRIPTION
# Fix Incorrect Cursors data on DM Messages GET API

## Fixes

- Fixed a bug where the DM Messages GET API returns incorrect cursors when the direction query is `backward`. This bug causes the prev and next cursors to be switched.